### PR TITLE
Refactored Enum Init

### DIFF
--- a/Device/UIDeviceExtension.swift
+++ b/Device/UIDeviceExtension.swift
@@ -21,44 +21,44 @@ public extension UIDevice {
 
 /// Enum representing the different types of iOS devices available
 public enum DeviceType: String, EnumProtocol {
-    case iPhone2G
-    case iPhone3G
-    case iPhone3GS
-    case iPhone4
-    case iPhone4S
-    case iPhone5
-    case iPhone5C
-    case iPhone5S
-    case iPhone6Plus
-    case iPhone6
-    case iPhone6S
-    case iPhone6SPlus
-    case iPhone7
-    case iPhone7Plus
-    case iPhoneSE
-    
-    case iPodTouch1G
-    case iPodTouch2G
-    case iPodTouch3G
-    case iPodTouch4G
-    case iPodTouch5G
-    
-    case iPad
-    case iPad2
-    case iPad3
-    case iPad4
-    case iPadMini
-    case iPadMiniRetina
-    case iPadMini3
-    case iPadMini4
-  
-    case iPadAir
-    case iPadAir2
-    
-    case iPadPro9Inch
-    case iPadPro12Inch
-    
-    case simulator
+	case iPhone2G
+	case iPhone3G
+	case iPhone3GS
+	case iPhone4
+	case iPhone4S
+	case iPhone5
+	case iPhone5C
+	case iPhone5S
+	case iPhone6Plus
+	case iPhone6
+	case iPhone6S
+	case iPhone6SPlus
+	case iPhone7
+	case iPhone7Plus
+	case iPhoneSE
+	
+	case iPodTouch1G
+	case iPodTouch2G
+	case iPodTouch3G
+	case iPodTouch4G
+	case iPodTouch5G
+	
+	case iPad
+	case iPad2
+	case iPad3
+	case iPad4
+	case iPadMini
+	case iPadMiniRetina
+	case iPadMini3
+	case iPadMini4
+	
+	case iPadAir
+	case iPadAir2
+	
+	case iPadPro9Inch
+	case iPadPro12Inch
+	
+	case simulator
 	case notAvailable
 	
 	/// Returns the current device type
@@ -72,7 +72,7 @@ public enum DeviceType: String, EnumProtocol {
 		var identifier = ""
 		
 		for child in mirror.children {
-			if let value = child.value as? Int8 , value != 0 {
+			if let value = child.value as? Int8, value != 0 {
 				identifier.append(String(UnicodeScalar(UInt8(value))))
 			}
 		}

--- a/Device/UIDeviceExtension.swift
+++ b/Device/UIDeviceExtension.swift
@@ -80,53 +80,6 @@ public enum DeviceType: String, EnumProtocol {
 		return DeviceType(identifier: identifier)
 	}
 	
-	/** Creates a device type
-	- parameters:
-		- identifier: The identifier of the device
-	- returns: The device type based on the provided identifier
-	*/
-	internal init(identifier: String) {
-		switch identifier {
-		case "i386", "x86_64": self = .simulator
-		case "iPhone1,1": self = .iPhone2G
-		case "iPhone1,2": self = .iPhone3G
-		case "iPhone2,1": self = .iPhone3GS
-		case "iPhone3,1", "iPhone3,2", "iPhone3,3": self = .iPhone4
-		case "iPhone4,1": self = .iPhone4S
-		case "iPhone5,1", "iPhone5,2": self = .iPhone5
-		case "iPhone5,3", "iPhone5,4": self = .iPhone5C
-		case "iPhone6,1", "iPhone6,2": self = .iPhone5S
-		case "iPhone7,1": self = .iPhone6Plus
-		case "iPhone7,2": self = .iPhone6
-		case "iPhone8,2": self = .iPhone6SPlus
-		case "iPhone8,1": self = .iPhone6S
-		case "iPhone8,4": self = .iPhoneSE
-		case "iPhone9,1", "iPhone9,3": self = .iPhone7
-		case "iPhone9,2", "iPhone9,4": self = .iPhone7Plus
-			
-		case "iPod1,1": self = .iPodTouch1G
-		case "iPod2,1": self = .iPodTouch2G
-		case "iPod3,1": self = .iPodTouch3G
-		case "iPod4,1": self = .iPodTouch4G
-		case "iPod5,1": self = .iPodTouch5G
-			
-		case "iPad1,1", "iPad1,2": self = .iPad
-		case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": self = .iPad2
-		case "iPad2,5", "iPad2,6", "iPad2,7": self = .iPadMini
-		case "iPad3,1", "iPad3,2", "iPad3,3": self = .iPad3
-		case "iPad3,4", "iPad3,5", "iPad3,6": self = .iPad4
-		case "iPad4,1", "iPad4,2", "iPad4,3": self = .iPadAir
-		case "iPad4,4", "iPad4,5", "iPad4,6": self = .iPadMiniRetina
-		case "iPad4,7", "iPad4,8": self = .iPadMini3
-		case "iPad5,1", "iPad5,2": self = .iPadMini4
-		case "iPad5,3", "iPad5,4": self = .iPadAir2
-		case "iPad6,3", "iPad6,4": self = .iPadPro9Inch
-		case "iPad6,7", "iPad6,8": self = .iPadPro12Inch
-			
-		default:
-			self = .notAvailable
-		}
-	}
 	
 	/// Returns the display name of the device type
 	var displayName: String {
@@ -167,6 +120,66 @@ public enum DeviceType: String, EnumProtocol {
 		case .simulator: return "Simulator"
 		case .notAvailable: return "Not Available"
 		}
+	}
+	
+	internal var identifiers: [String] {
+		
+		switch self {
+		case .notAvailable: return []
+		case .simulator: return ["i386", "x86_64"]
+		
+		case .iPhone2G: return ["iPhone1,1"]
+		case .iPhone3G: return ["iPhone1,2"]
+		case .iPhone3GS: return ["iPhone2,1"]
+		case .iPhone4: return ["iPhone3,1", "iPhone3,2", "iPhone3,3"]
+		case .iPhone4S: return ["iPhone4,1"]
+		case .iPhone5: return ["iPhone5,1", "iPhone5,2"]
+		case .iPhone5C: return ["iPhone5,3", "iPhone5,4"]
+		case .iPhone5S: return ["iPhone6,1", "iPhone6,2"]
+		case .iPhone6Plus: return ["iPhone7,1"]
+		case .iPhone6: return ["iPhone7,2"]
+		case .iPhone6S: return ["iPhone8,1"]
+		case .iPhone6SPlus: return ["iPhone8,2"]
+		case .iPhone7: return ["iPhone9,1", "iPhone9,3"]
+		case .iPhone7Plus: return ["iPhone9,2", "iPhone9,4"]
+		case .iPhoneSE: return ["iPhone8,4"]
+		
+		case .iPodTouch1G: return ["iPod1,1"]
+		case .iPodTouch2G: return ["iPod2,1"]
+		case .iPodTouch3G: return ["iPod3,1"]
+		case .iPodTouch4G: return ["iPod4,1"]
+		case .iPodTouch5G: return ["iPod5,1"]
+		
+		case .iPad: return ["iPad1,1", "iPad1,2"]
+		case .iPad2: return ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"]
+		case .iPad3: return ["iPad3,1", "iPad3,2", "iPad3,3"]
+		case .iPad4: return ["iPad3,4", "iPad3,5", "iPad3,6"]
+		case .iPadMini: return ["iPad2,5", "iPad2,6", "iPad2,7"]
+		case .iPadMiniRetina: return ["iPad4,4", "iPad4,5", "iPad4,6"]
+		case .iPadMini3: return ["iPad4,7", "iPad4,8"]
+		case .iPadMini4: return ["iPad5,1", "iPad5,2"]
+		case .iPadAir: return ["iPad4,1", "iPad4,2", "iPad4,3"]
+		case .iPadAir2: return ["iPad5,3", "iPad5,4"]
+		case .iPadPro9Inch: return ["iPad6,3", "iPad6,4"]
+		case .iPadPro12Inch: return ["iPad6,7", "iPad6,8"]
+		}
+	}
+	
+	/** Creates a device type
+	- parameter identifier: The identifier of the device
+	- returns: The device type based on the provided identifier
+	*/
+	internal init(identifier: String) {
+		
+		for device in DeviceType.all {
+			for deviceId in device.identifiers {
+				guard identifier == deviceId else { continue }
+				self = device
+				return
+			}
+		}
+		
+		self = .notAvailable
 	}
 }
 

--- a/Device/UIDeviceExtension.swift
+++ b/Device/UIDeviceExtension.swift
@@ -14,7 +14,7 @@ import UIKit
 public extension UIDevice {
 	
 	/// Returns the `DeviceType` of the device in use
-	var deviceType: DeviceType {
+	public var deviceType: DeviceType {
 		return DeviceType.current
 	}
 }
@@ -61,6 +61,8 @@ public enum DeviceType: String, EnumProtocol {
 	case simulator
 	case notAvailable
 	
+	// MARK: Constants
+	
 	/// Returns the current device type
 	public static var current: DeviceType {
 		
@@ -80,9 +82,10 @@ public enum DeviceType: String, EnumProtocol {
 		return DeviceType(identifier: identifier)
 	}
 	
+	// MARK: Variables
 	
 	/// Returns the display name of the device type
-	var displayName: String {
+	public var displayName: String {
 		
 		switch self {
 		case .iPhone2G: return "iPhone 2G"
@@ -164,6 +167,8 @@ public enum DeviceType: String, EnumProtocol {
 		case .iPadPro12Inch: return ["iPad6,7", "iPad6,8"]
 		}
 	}
+	
+	// MARK: Inits
 	
 	/** Creates a device type
 	- parameter identifier: The identifier of the device

--- a/DeviceTests/DeviceTests.swift
+++ b/DeviceTests/DeviceTests.swift
@@ -60,7 +60,9 @@ class DeviceTests: XCTestCase {
 	let simulatorTypes: [String] = ["i386", "x86_64"]
 	
 	let iPhoneTypes: [String] = {
-		return ["iPhone1,1", "iPhone1,2", "iPhone2,1", "iPhone3,1", "iPhone3,1", "iPhone3,2", "iPhone3,3", "iPhone4,1", "iPhone5,1", "iPhone5,2", "iPhone5,3", "iPhone5,4", "iPhone6,1", "iPhone6,2", "iPhone7,1", "iPhone7,2", "iPhone8,2", "iPhone8,1", "iPhone8,4"]
+		return ["iPhone1,1", "iPhone1,2", "iPhone2,1", "iPhone3,1", "iPhone3,1", "iPhone3,2",
+		        "iPhone3,3", "iPhone4,1", "iPhone5,1", "iPhone5,2", "iPhone5,3", "iPhone5,4",
+		        "iPhone6,1", "iPhone6,2", "iPhone7,1", "iPhone7,2", "iPhone8,2", "iPhone8,1", "iPhone8,4"]
 	}()
 	
 	let iPodTypes: [String] = {
@@ -68,7 +70,10 @@ class DeviceTests: XCTestCase {
 	}()
 	
 	var iPadTypes: [String] {
-		return ["iPad1,1", "iPad1,2", "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4", "iPad2,5", "iPad2,6", "iPad2,7", "iPad3,1", "iPad3,2", "iPad3,3", "iPad3,4", "iPad3,5", "iPad3,6", "iPad4,1", "iPad4,2", "iPad4,3", "iPad4,4", "iPad4,5", "iPad4,6", "iPad4,7", "iPad4,8", "iPad5,1", "iPad5,2", "iPad5,3", "iPad5,4", "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8"]
+		return ["iPad1,1", "iPad1,2", "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4", "iPad2,5",
+		        "iPad2,6", "iPad2,7", "iPad3,1", "iPad3,2", "iPad3,3", "iPad3,4", "iPad3,5",
+		        "iPad3,6", "iPad4,1", "iPad4,2", "iPad4,3", "iPad4,4", "iPad4,5", "iPad4,6",
+		        "iPad4,7", "iPad4,8", "iPad5,1", "iPad5,2", "iPad5,3", "iPad5,4", "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8"]
 	}
 	
     override func setUp() {

--- a/DeviceTests/DeviceTests.swift
+++ b/DeviceTests/DeviceTests.swift
@@ -9,6 +9,52 @@
 import XCTest
 @testable import Device
 
+fileprivate extension DeviceType {
+	
+	var testIdentifiers: [String] {
+		
+		switch self {
+		case .notAvailable: return []
+		case .simulator: return ["i386", "x86_64"]
+			
+		case .iPhone2G: return ["iPhone1,1"]
+		case .iPhone3G: return ["iPhone1,2"]
+		case .iPhone3GS: return ["iPhone2,1"]
+		case .iPhone4: return ["iPhone3,1", "iPhone3,2", "iPhone3,3"]
+		case .iPhone4S: return ["iPhone4,1"]
+		case .iPhone5: return ["iPhone5,1", "iPhone5,2"]
+		case .iPhone5C: return ["iPhone5,3", "iPhone5,4"]
+		case .iPhone5S: return ["iPhone6,1", "iPhone6,2"]
+		case .iPhone6Plus: return ["iPhone7,1"]
+		case .iPhone6: return ["iPhone7,2"]
+		case .iPhone6S: return ["iPhone8,1"]
+		case .iPhone6SPlus: return ["iPhone8,2"]
+		case .iPhone7: return ["iPhone9,1", "iPhone9,3"]
+		case .iPhone7Plus: return ["iPhone9,2", "iPhone9,4"]
+		case .iPhoneSE: return ["iPhone8,4"]
+			
+		case .iPodTouch1G: return ["iPod1,1"]
+		case .iPodTouch2G: return ["iPod2,1"]
+		case .iPodTouch3G: return ["iPod3,1"]
+		case .iPodTouch4G: return ["iPod4,1"]
+		case .iPodTouch5G: return ["iPod5,1"]
+			
+		case .iPad: return ["iPad1,1", "iPad1,2"]
+		case .iPad2: return ["iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4"]
+		case .iPad3: return ["iPad3,1", "iPad3,2", "iPad3,3"]
+		case .iPad4: return ["iPad3,4", "iPad3,5", "iPad3,6"]
+		case .iPadMini: return ["iPad2,5", "iPad2,6", "iPad2,7"]
+		case .iPadMiniRetina: return ["iPad4,4", "iPad4,5", "iPad4,6"]
+		case .iPadMini3: return ["iPad4,7", "iPad4,8"]
+		case .iPadMini4: return ["iPad5,1", "iPad5,2"]
+		case .iPadAir: return ["iPad4,1", "iPad4,2", "iPad4,3"]
+		case .iPadAir2: return ["iPad5,3", "iPad5,4"]
+		case .iPadPro9Inch: return ["iPad6,3", "iPad6,4"]
+		case .iPadPro12Inch: return ["iPad6,7", "iPad6,8"]
+		}
+	}
+}
+
 class DeviceTests: XCTestCase {
 	
 	let simulatorTypes: [String] = ["i386", "x86_64"]
@@ -63,8 +109,10 @@ class DeviceTests: XCTestCase {
 		let emptyDevice = DeviceType(identifier: "")
 		XCTAssertEqual(emptyDevice, DeviceType.notAvailable)
 		
-		for (_, type) in DeviceType.all.enumerated() {
+		for type in DeviceType.all {
 			XCTAssertFalse(type.displayName.isEmpty)
+			
+			XCTAssert(type.identifiers == type.testIdentifiers)
 		}
     }
 }


### PR DESCRIPTION
By adding the variable `identifiers`, this ensures that, when a new device type is added, the compiler will prompt the addition of the possible identifiers. This also makes DeviceType more testable