### PR TITLE
Remove compiler warning

### DIFF
--- a/Device/UIDeviceExtension.swift
+++ b/Device/UIDeviceExtension.swift
@@ -240,7 +240,7 @@ public enum DeviceType: String, CaseIterable {
 public extension UIDevice {
 
     /// The `DeviceType` of the device in use
-    public var deviceType: DeviceType {
+    var deviceType: DeviceType {
         return DeviceType.current
     }
 }


### PR DESCRIPTION
'public' modifier is redundant for property declared in a public extension